### PR TITLE
Add a method to retrieve the URL used in API call

### DIFF
--- a/Source/ObjectiveFlickr.h
+++ b/Source/ObjectiveFlickr.h
@@ -149,6 +149,9 @@ typedef id OFFlickrAPIRequestDelegateType;
 - (BOOL)callAPIMethodWithGET:(NSString *)inMethodName arguments:(NSDictionary *)inArguments;
 - (BOOL)callAPIMethodWithPOST:(NSString *)inMethodName arguments:(NSDictionary *)inArguments;
 
+// methods to call from threads / blocking connections
+- (NSURL *)urlAPIMethodWithGET:(NSString *)inMethodName arguments:(NSDictionary *)inArguments;
+
 // image upload—we use NSInputStream here because we want to have flexibity; with this you can upload either a file or NSData from NSImage
 - (BOOL)uploadImageStream:(NSInputStream *)inImageStream suggestedFilename:(NSString *)inFilename MIMEType:(NSString *)inType arguments:(NSDictionary *)inArguments;
 

--- a/Source/ObjectiveFlickr.m
+++ b/Source/ObjectiveFlickr.m
@@ -357,6 +357,17 @@ typedef unsigned int NSUInteger;
 	return [HTTPRequest performMethod:LFHTTPRequestGETMethod onURL:[NSURL URLWithString:URLString] withData:nil];
 }
 
+- (NSURL *)urlAPIMethodWithGET:(NSString *)inMethodName arguments:(NSDictionary *)inArguments
+{
+	// combine the parameters
+	NSMutableDictionary *newArgs = inArguments ? [NSMutableDictionary dictionaryWithDictionary:inArguments] : [NSMutableDictionary dictionary];
+	[newArgs setObject:inMethodName forKey:@"method"];
+	NSString *query = [context signedQueryFromArguments:newArgs];
+	NSString *URLString = [NSString stringWithFormat:@"%@?%@", [context RESTAPIEndpoint], query];
+
+	return [NSURL URLWithString:URLString];
+}
+
 - (BOOL)callAPIMethodWithPOST:(NSString *)inMethodName arguments:(NSDictionary *)inArguments
 {
     if ([HTTPRequest isRunning]) {


### PR DESCRIPTION
This allows you to retrieve the proper URL for the API call you want to perform. It can be used within threads to create blocking connections, or for other purposes. There is also a helper function to let you retrieve the dictionary.
