### PR TITLE
Add a method to retrieve the URL used in API call

### DIFF
--- a/Source/ObjectiveFlickr.h
+++ b/Source/ObjectiveFlickr.h
@@ -151,6 +151,7 @@ typedef id OFFlickrAPIRequestDelegateType;
 
 // methods to call from threads / blocking connections
 - (NSURL *)urlAPIMethodWithGET:(NSString *)inMethodName arguments:(NSDictionary *)inArguments;
+- (NSDictionary *)dictionaryFromRequestData:(NSData *)requestData;
 
 // image upload—we use NSInputStream here because we want to have flexibity; with this you can upload either a file or NSData from NSImage
 - (BOOL)uploadImageStream:(NSInputStream *)inImageStream suggestedFilename:(NSString *)inFilename MIMEType:(NSString *)inType arguments:(NSDictionary *)inArguments;

--- a/Source/ObjectiveFlickr.m
+++ b/Source/ObjectiveFlickr.m
@@ -368,6 +368,10 @@ typedef unsigned int NSUInteger;
 	return [NSURL URLWithString:URLString];
 }
 
+- (NSDictionary *)dictionaryFromRequestData:(NSData *)requestData {
+	return [OFXMLMapper dictionaryMappedFromXMLData:requestData];
+}
+
 - (BOOL)callAPIMethodWithPOST:(NSString *)inMethodName arguments:(NSDictionary *)inArguments
 {
     if ([HTTPRequest isRunning]) {


### PR DESCRIPTION
This allows you to retrieve the proper URL for the API call you want to perform. It can be used within threads to create blocking connections, or for other purposes. There is also a helper function to let you retrieve the dictionary.
