### PR TITLE
Added missing i386 to Debug for iOS library

### DIFF
--- a/ObjectiveFlickr.xcodeproj/project.pbxproj
+++ b/ObjectiveFlickr.xcodeproj/project.pbxproj
@@ -474,7 +474,7 @@
 				PRODUCT_NAME = ObjectiveFlickr;
 				RUN_CLANG_STATIC_ANALYZER = NO;
 				SDKROOT = iphoneos;
-				VALID_ARCHS = "armv6 armv7";
+				VALID_ARCHS = "armv6 armv7 i386";
 			};
 			name = Debug;
 		};


### PR DESCRIPTION
This is necessary because otherwise xcodebuild fails to build with this error when building Debug for iphonesimulator. This becomes apparent if you try to build Objective Flickr with xcodebuild, e.g. in continuous integration. 

xcodebuild -sdk iphonesimulator -target "ObjectiveFlickr (library)" -configuration Debug
Build settings from command line:
    SDKROOT = iphonesimulator5.1

=== BUILD NATIVE TARGET ObjectiveFlickr (library) OF PROJECT ObjectiveFlickr WITH CONFIGURATION Debug ===
Check dependencies
No architectures to compile for (ONLY_ACTIVE_ARCH=YES, active arch=i386, VALID_ARCHS=armv6 armv7).
