### PR TITLE
armv7s support

### DIFF
--- a/ObjectiveFlickr.xcodeproj/project.pbxproj
+++ b/ObjectiveFlickr.xcodeproj/project.pbxproj
@@ -479,7 +479,7 @@
 				PRODUCT_NAME = ObjectiveFlickr;
 				RUN_CLANG_STATIC_ANALYZER = NO;
 				SDKROOT = iphoneos;
-				VALID_ARCHS = "armv6 armv7 i386";
+				VALID_ARCHS = "armv6 armv7 i386 armv7s";
 			};
 			name = Debug;
 		};
@@ -496,7 +496,7 @@
 				PRODUCT_NAME = ObjectiveFlickr;
 				RUN_CLANG_STATIC_ANALYZER = NO;
 				SDKROOT = iphoneos;
-				VALID_ARCHS = "armv6 armv7";
+				VALID_ARCHS = "armv6 armv7 armv7s";
 				ZERO_LINK = NO;
 			};
 			name = Release;


### PR DESCRIPTION
This pull request adds the armv7s architecture to the iOS project, thereby making it compatible with iOS projects configured to build for armv7s (iPhone 5). Closes issue #41.
