### PR TITLE
Added 64bit / arm64 support for ObjectiveFlickr

### DIFF
--- a/ObjectiveFlickr.xcodeproj/project.pbxproj
+++ b/ObjectiveFlickr.xcodeproj/project.pbxproj
@@ -468,17 +468,17 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_GC = unsupported;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_VERSION = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				PRODUCT_NAME = ObjectiveFlickr;
 				RUN_CLANG_STATIC_ANALYZER = NO;
 				SDKROOT = iphoneos;
-				VALID_ARCHS = "armv6 armv7 i386 armv7s";
+				VALID_ARCHS = "armv6 armv7 i386 armv7s arm64";
 			};
 			name = Debug;
 		};
@@ -486,16 +486,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_ENABLE_OBJC_GC = unsupported;
 				GCC_VERSION = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				PRODUCT_NAME = ObjectiveFlickr;
 				RUN_CLANG_STATIC_ANALYZER = NO;
 				SDKROOT = iphoneos;
-				VALID_ARCHS = "armv6 armv7 armv7s";
+				VALID_ARCHS = "armv6 armv7 armv7s arm64";
 				ZERO_LINK = NO;
 			};
 			name = Release;


### PR DESCRIPTION
Removed < iOS 6.0 Support. 

Apple only included $(ARCHS_STANDARD_INCLUDING_64_BIT) starting iOS SDK 6.0. ( CMIIW. )
